### PR TITLE
Missed crate entry in super_player example

### DIFF
--- a/Chapter04/super_player/src/main.rs
+++ b/Chapter04/super_player/src/main.rs
@@ -1,6 +1,7 @@
 // super_player/src/main.rs
 
 mod media;
+use crate::media::Playable;
 
 struct Audio(String);
 struct Video(String);


### PR DESCRIPTION
Fix for issue #8 as discussed  this will make build the example.